### PR TITLE
feat: closes #34: verificações adicionais antes de iniciar a aplicação

### DIFF
--- a/xram_memory/__init__.py
+++ b/xram_memory/__init__.py
@@ -1,28 +1,23 @@
 from __future__ import absolute_import, unicode_literals
-import os
-import socket
 from django.core.checks import register, Warning, Critical
-from kombu import Connection
 from kombu.exceptions import OperationalError
+from urllib3.exceptions import HTTPError
+from elasticsearch import Elasticsearch
 from django.conf import settings
+from kombu import Connection
+import socket
+import os
+import tempfile
+
+
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.
 from .celery import app as celery_app
 
 
-@register()
+@register(deploy=True)
 def celery_broker_check(app_configs, **kwargs):
     errors = []
-
-    if os.environ['DJANGO_CONFIGURATION'] == 'Development':
-        errors.append(
-            Warning(
-                'Pulando as verificações sobre o servidor de fila, pois estamos em desenvolvimento.',
-                hint="Pode ser que o aplicativo não funcione corretamente"
-            )
-        )
-        return errors
-
     try:
         conn = Connection(settings.CELERY_BROKER_URL)
         conn.ensure_connection(max_retries=3)
@@ -48,6 +43,63 @@ def celery_broker_check(app_configs, **kwargs):
                 id='xram_memory.CeleryBrokerConnectionError',
             )
         )
+    return errors
+
+
+@register(deploy=True)
+def check_elastic_search(app_configs, **kwargs):
+    errors = []
+    try:
+        elastic_host = settings.ELASTICSEARCH_DSL['default']['hosts']
+        es = Elasticsearch(elastic_host, verify_certs=True)
+        if not es.ping():
+            raise ValueError("Connection failed")
+    except (ValueError, HTTPError):
+        errors.append(Critical(
+            'Falha ao tentar conexão com o Elasticsearch',
+            obj=es,
+            id='xram_memory.ElasticSearchError',
+        ))
+    return errors
+
+
+@register(deploy=True)
+def check_libraries(app_configs, **kwargs):
+    errors = []
+
+    # cria um arquivo temporário e abre ele com a libmagic para verificar se a biblioteca está funcionando
+    try:
+        import magic
+        with tempfile.TemporaryFile() as f:
+            mimetype = magic.from_buffer(f.read(1024), mime=True)
+    except:
+        errors.append(Critical(
+            "Biblioteca lib_magic não está funcional.",
+            id='xram_memory.CheckLibrariesError',
+        ))
+
+    # gera um pdf de uma string para verificar se wkhtmltopdf está funcional
+    try:
+        import pdfkit
+        result = pdfkit.from_string('teste', False)
+        if not result:
+            raise ValueError
+    except:
+        errors.append(Critical(
+            "wkhtmltopdf não está funcional.",
+            id='xram_memory.CheckLibrariesError',
+        ))
+
+    # importa o corpus do ntlk usado pelo newspaper3k para verificar se esse foi baixado
+    try:
+        from nltk.corpus import brown, movie_reviews, wordnet, stopwords
+        from nltk.tokenize import punkt
+    except ImportError as e:
+        errors.append(Critical(
+            "Falha ao importar nltk e/ou nltk corpora",
+            id='xram_memory.CheckLibrariesError',
+        ))
+
     return errors
 
 


### PR DESCRIPTION
- Testes devem acontecer apenas com o 'check --deploy'
- Verifique conexão com o Elasticsearch
- Verifique libmagic, wkhtmltopdf, ntlk e seu corpus